### PR TITLE
Update addon.xml - remove first empty line

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,3 @@
-  
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.database.cleaner"
       name="Video Database Cleaner"


### PR DESCRIPTION
this can cause errors in some backup addons that examine addon.xml file with xmltree