### PR TITLE
Fix missing texturecache log on Windows

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,4 @@
-  
-<?xml version="1.1" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="script.database.cleaner"
       name="Video Database Cleaner"
       version="3.0.0"


### PR DESCRIPTION
Hi, thanks for the continuation of script.database.cleaner and integrating texturecache.py.

I had a problem where the cleaner log would only show normal output and not from texturecache.py. It only occurred on Windows and not on Linux (Vero4k/OSMC). 

Problem occurs with these settings:
- Log paths to database-cleaner.log (logtolog/enable_logging ON)
- Show summary window (promptdelete ON)
- Enable Texturecache runs (runtexturecache ON)
- Pipe Texturecache output to database.cleaner logfile (debugtexturecache ON)

Cause:
create_log_file gets called twice when reaching the cleaning stage. The second call opens a second handle on the already opened (or "not-closed") database-cleaner.log. Linux is apparently fine with this but Windows isn't. By the time texturecache.py wants to write to the global_logfile handle, it cannot.

Solution:
fixed it by using a better way to deal with files (resources are always properly closed/cleaned).